### PR TITLE
Update CMake files

### DIFF
--- a/asv_sim/CMakeLists.txt
+++ b/asv_sim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(asv_sim)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/asv_sim_gazebo/CMakeLists.txt
+++ b/asv_sim_gazebo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(asv_sim_gazebo)
 
 find_package(catkin REQUIRED COMPONENTS)

--- a/asv_sim_gazebo_plugins/CMakeLists.txt
+++ b/asv_sim_gazebo_plugins/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(asv_sim_gazebo_plugins)
 
 ###############################################################################
-# Compile as C++11, required by Gazebo11
+# Compile as C++17, required by Gazebo11
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/asv_sim_gazebo_plugins/CMakeLists.txt
+++ b/asv_sim_gazebo_plugins/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 2.8.3)
 project(asv_sim_gazebo_plugins)
 
 ###############################################################################
-# Compile as C++11, supported in ROS Kinetic and newer
+# Compile as C++11, required by Gazebo11
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ###############################################################################
@@ -19,27 +19,28 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(gazebo REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Protobuf REQUIRED)
+# find_package(GTest REQUIRED)
 
 ############################################################################### 
 # Catkin...
 
 catkin_package(
-  INCLUDE_DIRS
-    include
-    ${Boost_INCLUDE_DIRS}
-    ${catkin_INCLUDE_DIRS}
-    ${GAZEBO_INCLUDE_DIRS}
-    ${GAZEBO_PROTO_INCLUDE_DIRS}
+    INCLUDE_DIRS
+        include
+        ${Boost_INCLUDE_DIRS}
+        ${catkin_INCLUDE_DIRS}
+        ${GAZEBO_INCLUDE_DIRS}
+        ${GAZEBO_PROTO_INCLUDE_DIRS}
     LIBRARIES
-    asv_sim_gazebo_plugins
-    asv_sim_gazebo_plugins_msgs
-    RegisterSensorsPlugin
-    SailLiftDragPlugin
+        asv_sim_gazebo_plugins
+        asv_sim_gazebo_plugins_msgs
+        RegisterSensorsPlugin
+        SailLiftDragPlugin
     DEPENDS
-    gazebo_ros
-    geometry_msgs
-    roscpp
-    std_msgs
+        gazebo_ros
+        geometry_msgs
+        roscpp
+        std_msgs
 )
 
 include_directories(
@@ -48,6 +49,7 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
+  ${GAZEBO_MSG_INCLUDE_DIRS}
   ${GAZEBO_PROTO_INCLUDE_DIRS}
   ${IGNITION-COMMON_INCLUDE_DIRS}
   ${IGNITION-MATHS_INCLUDE_DIRS}

--- a/asv_sim_gazebo_plugins/package.xml
+++ b/asv_sim_gazebo_plugins/package.xml
@@ -9,13 +9,14 @@
   <maintainer email="rhys.mainwaring@me.com">Rhys Mainwaring</maintainer>
   <license>GPLv3</license>
   <author email="rhys.mainwaring@me.com">Rhys Mainwaring</author>
-  <buildtool_depend>catkin</buildtool_depend>
   <url type="website">https://github.com/srmainwaring/asv_sim</url>
   <url type="repository">https://github.com/srmainwaring/asv_sim</url>
   <url type="bugtracker">https://github.com/srmainwaring/asv_sim/issues</url>
+  <buildtool_depend>catkin</buildtool_depend>
   <depend>gazebo_ros</depend>
   <depend>geometry_msgs</depend>
   <depend>roscpp</depend>
+  <depend>rosunit</depend>
   <depend>std_msgs</depend>
   <export>
     <gazebo_ros plugin_path="${prefix}/lib"/>


### PR DESCRIPTION
- Update CXX standard
- Update cmake version
- Add dependency on GAZEBO_MSG headers

Consolidate branches prior to migration to gz-sim7.