### PR TITLE
SailLiftDrag: fix sign of free-stream velocity

### DIFF
--- a/asv_sim_gazebo_plugins/src/systems/foil_lift_drag/FoilLiftDrag.cc
+++ b/asv_sim_gazebo_plugins/src/systems/foil_lift_drag/FoilLiftDrag.cc
@@ -192,17 +192,6 @@ void FoilLiftDrag::PreUpdate(
   this->dataPtr->link.EnableVelocityChecks(_ecm, true);
   this->dataPtr->link.EnableAccelerationChecks(_ecm, true);
 
-  /// \todo(srmainwaring) get wind model accounting for wind effects plugin
-  // wind velocity
-  auto velWindWorld = math::Vector3d::Zero;
-  Entity windEntity = _ecm.EntityByComponents(components::Wind());
-  auto velWindWorldComp =
-      _ecm.Component<components::WorldLinearVelocity>(windEntity);
-  if (velWindWorldComp)
-  {
-    velWindWorld = velWindWorldComp->Data();
-  }
-
   // Pose of link origin and link CoM (world frame).
   auto linkPoseWorldOpt = this->dataPtr->link.WorldPose(_ecm);
   if (!linkPoseWorldOpt.has_value())
@@ -217,7 +206,7 @@ void FoilLiftDrag::PreUpdate(
   auto velCpWorld = velCpWorldComp.value();
 
   // Free stream velocity at centre of pressure (world frame).
-  auto velWorld = velCpWorld - velWindWorld;
+  auto velWorld = - velCpWorld;
 
   // Compute lift and drag in world frame
   double alpha = 0;

--- a/asv_sim_gazebo_plugins/src/systems/sail_lift_drag/SailLiftDrag.cc
+++ b/asv_sim_gazebo_plugins/src/systems/sail_lift_drag/SailLiftDrag.cc
@@ -139,7 +139,7 @@ void SailLiftDrag::Configure(
   }
 
   {
-    double rate = 50.0;
+    double rate = 1.0;
     std::chrono::duration<double> period{rate > 0.0 ? 1.0 / rate : 0.0};
     this->dataPtr->updatePeriod = std::chrono::duration_cast<
         std::chrono::steady_clock::duration>(period);
@@ -217,7 +217,7 @@ void SailLiftDrag::PreUpdate(
   auto velCpWorld = velCpWorldComp.value();
 
   // Free stream velocity at centre of pressure (world frame).
-  auto velWorld = velCpWorld - velWindWorld;
+  auto velWorld = velWindWorld - velCpWorld;
 
   // Compute lift and drag in world frame
   double alpha = 0;
@@ -240,7 +240,7 @@ void SailLiftDrag::PreUpdate(
   lift.Correct();
   drag.Correct();
 
-#if 1
+#if 0
   auto elapsed = _info.simTime - this->dataPtr->lastUpdateTime;
   if (elapsed >= this->dataPtr->updatePeriod)
   {


### PR DESCRIPTION
Issue with sail lift drag plugin raised here: https://discord.com/channels/1022170275984457759/1080941771925749822/1083095435297693827

- Sign of the free-stream velocity flipped during porting. Correcting.
- Remove debug prints from sail plugin.
- Remove wind from the foil plugin.

## Test

Figure 1: Lift and drag for u=-3.5 m/s, AoA = 0.5 rad.
![wing-sail-lift-drag-fix-aoa=0 5](https://user-images.githubusercontent.com/24916364/223843213-01d2a345-4d43-4a67-9d36-0ba1fb1f6c25.jpg)

Figure 2: Lift and drag for u=-3.5 m/s, AoA = 1.55 rad.
![wing-sail-lift-drag-fix-aoa=1 55](https://user-images.githubusercontent.com/24916364/223843219-ae0790e1-5d1a-4d88-b1c0-9fc36a4e04a5.jpg)

Figure 2: Lift and drag for u=-3.5 m/s, AoA = 2.35 rad.
![wing-sail-lift-drag-fix-aoa=2 35](https://user-images.githubusercontent.com/24916364/223843221-fee3139e-7291-4dfb-b61f-70a6055f9543.jpg)

