### PR TITLE
LiftDrag: check for overflow

### DIFF
--- a/asv_sim_gazebo_plugins/src/systems/foil_lift_drag/FoilLiftDrag.cc
+++ b/asv_sim_gazebo_plugins/src/systems/foil_lift_drag/FoilLiftDrag.cc
@@ -230,15 +230,25 @@ void FoilLiftDrag::PreUpdate(
   drag.Correct();
 
   // Add force and torque to link (applied at link origin in world frame).
+  if (lift.IsFinite() && liftTorque.IsFinite())
   {
     auto link = Link(this->dataPtr->link.Entity());
     // link.SetVisualizationLabel("FoilLift");
     link.AddWorldWrench(_ecm, lift, liftTorque);
   }
+  else
+  {
+    gzwarn << "FoilLiftDrag: overflow in lift calculation\n";
+  }
+  if (drag.IsFinite() && dragTorque.IsFinite())
   {
     auto link = Link(this->dataPtr->link.Entity());
     // link.SetVisualizationLabel("FoilDrag");
     link.AddWorldWrench(_ecm, drag, dragTorque);
+  }
+  else
+  {
+    gzwarn << "FoilLiftDrag: overflow in drag calculation\n";
   }
 
   /// \todo(srmainwaring) enable force publishing / visualization.

--- a/asv_sim_gazebo_plugins/src/systems/sail_lift_drag/SailLiftDrag.cc
+++ b/asv_sim_gazebo_plugins/src/systems/sail_lift_drag/SailLiftDrag.cc
@@ -285,15 +285,25 @@ void SailLiftDrag::PreUpdate(
 #endif
 
   // Add force and torque to link (applied at link origin in world frame).
+  if (lift.IsFinite() && liftTorque.IsFinite())
   {
     auto link = Link(this->dataPtr->link.Entity());
     // link.SetVisualizationLabel("SailLift");
     link.AddWorldWrench(_ecm, lift, liftTorque);
   }
+  else
+  {
+    gzwarn << "SailLiftDrag: overflow in lift calculation\n";
+  }
+  if (drag.IsFinite() && dragTorque.IsFinite())
   {
     auto link = Link(this->dataPtr->link.Entity());
     // link.SetVisualizationLabel("SailDrag");
     link.AddWorldWrench(_ecm, drag, dragTorque);
+  }
+  else
+  {
+    gzwarn << "SailLiftDrag: overflow in drag calculation\n";
   }
 
   /// \todo(srmainwaring) enable force publishing / visualization.


### PR DESCRIPTION
The SailLiftDrag and FoilLiftDrag plugins can propagate overflows to AddWorldWrench which can cause hard to trace solver failures. This adds an extra check (although the call to `Vector3d::Correct` should have prevented this).