### PR TITLE
LiftDrag: fix angle of attack calculation

### DIFF
--- a/.github/workflows/ubuntu-jammy-ci.yml
+++ b/.github/workflows/ubuntu-jammy-ci.yml
@@ -14,15 +14,25 @@ jobs:
 
       - name: Install Build Essentials
         run: |
-          sudo apt-get update
-          sudo apt-get install wget lsb-release gnupg curl
+          sudo apt-get update && sudo apt-get install \
+          wget \
+          lsb-release \
+          gnupg \
+          curl \
+          software-properties-common
 
       - name: Install Build Tools
         run: |
-          sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list'
-          curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
-          sudo apt-get update
-          sudo apt-get install python3-pip python3-vcstool python3-colcon-common-extensions
+          sudo add-apt-repository universe
+          sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+          sudo apt update && sudo apt install -y \
+          python3-colcon-common-extensions \
+          python3-flake8-docstrings \
+          python3-pip \
+          python3-pytest-cov \
+          python3-vcstool \
+          ros-dev-tools
 
       - name: Install Gazebo Garden
         run: |
@@ -33,7 +43,10 @@ jobs:
 
       - name: Build
         run: |
-          colcon build --symlink-install --merge-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTING=ON
+          colcon build --symlink-install --merge-install --cmake-args \
+          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+          -DCMAKE_CXX_STANDARD=17 \
+          -DBUILD_TESTING=ON
 
       - name: Test
         run: |

--- a/asv_sim_gazebo_plugins/src/LiftDragModel.cc
+++ b/asv_sim_gazebo_plugins/src/LiftDragModel.cc
@@ -168,7 +168,7 @@ void LiftDragModel::Compute(
   // Compute the angle of attack, alpha:
   // This is the angle between the free stream velocity
   // projected into the lift-drag plane and the forward vector
-  auto velLD = _velU - _velU.Dot(spanI) * velUnit;
+  auto velLD = _velU - _velU.Dot(spanI) * spanI;
 
   // Get direction of drag
   auto dragUnit = velLD;

--- a/asv_sim_gazebo_plugins/src/LiftDragModel.cc
+++ b/asv_sim_gazebo_plugins/src/LiftDragModel.cc
@@ -221,8 +221,11 @@ void LiftDragModel::Compute(
   gzmsg << "dragUnit:     " << dragUnit << "\n";
   gzmsg << "liftUnit:     " << liftUnit << "\n";
   gzmsg << "alpha:        " << alpha << "\n";
+  gzmsg << "u:            " << _u << "\n";
+  gzmsg << "cl:           " << _cl << "\n";
+  gzmsg << "cd:           " << _cd << "\n";
   gzmsg << "lift:         " << _lift << "\n";
-  gzmsg << "drag:         " << _drag << "\n";
+  gzmsg << "drag:         " << _drag << "\n\n";
 #endif
 }
 

--- a/asv_sim_gazebo_plugins/src/LiftDragModel.cc
+++ b/asv_sim_gazebo_plugins/src/LiftDragModel.cc
@@ -118,7 +118,7 @@ LiftDragModel* LiftDragModel::Create(
   if (!data->radialSymmetry)
   {
     gzerr << "LiftDragModel only supports radially symmetric foils\n";
-    return 0;
+    return nullptr;
   }
 
   // Normalise

--- a/asv_sim_gazebo_plugins/src/systems/sail_lift_drag/SailLiftDrag.cc
+++ b/asv_sim_gazebo_plugins/src/systems/sail_lift_drag/SailLiftDrag.cc
@@ -145,34 +145,6 @@ void SailLiftDrag::Configure(
         std::chrono::steady_clock::duration>(period);
   }
 
-  /// \todo(srmainwaring) implement publishing forces.
-#if 0
-  auto getTopic = [&, this]() -> std::string
-  {
-    std::string topic;
-
-    this->LoadParam(this->dataPtr->sdf, "topic", topic, "lift_drag");
-
-    std::string topicName = "~";
-    if (this->dataPtr->link != nullptr)
-    {
-      topicName += '/' + this->dataPtr->link->GetName();
-    }
-    topicName += '/' + topic;
-    boost::replace_all(topicName, "::", "/");
-
-    return topicName;
-  }
-
-  // Publishers
-  std::string topic = this->GetTopic();
-  this->dataPtr->liftDragPub
-    = this->dataPtr->node->Advertise<asv_msgs::msgs::LiftDrag>(topic);
-
-  // Time
-  this->dataPtr->prevTime = this->dataPtr->world->SimTime();
-#endif
-
   // Lift / Drag model
   this->dataPtr->liftDrag.reset(asv::LiftDragModel::Create(_sdf));
 }
@@ -185,7 +157,7 @@ void SailLiftDrag::PreUpdate(
   if (_info.paused)
     return;
 
-  if (!this->dataPtr->link.Valid(_ecm))
+  if (!this->dataPtr->link.Valid(_ecm) || !this->dataPtr->liftDrag)
     return;
 
   // ensure components are available
@@ -305,43 +277,6 @@ void SailLiftDrag::PreUpdate(
   {
     gzwarn << "SailLiftDrag: overflow in drag calculation\n";
   }
-
-  /// \todo(srmainwaring) enable force publishing / visualization.
-#if 0
-  // Publish message
-  const double updateRate = 50.0;
-  const double updateInterval = 1.0/updateRate;
-  common::Time simTime = this->dataPtr->world->SimTime();
-  if ((simTime - this->dataPtr->prevTime).Double() < updateInterval)
-  {
-    return;
-  }
-  this->dataPtr->prevTime = simTime;
-
-  // Save the time of the measurement
-  asv_msgs::msgs::LiftDrag liftDragMsg;
-  msgs::Set(liftDragMsg.mutable_time(), simTime);
-
-  msgs::Set(liftDragMsg.mutable_lift(), lift);
-  msgs::Set(liftDragMsg.mutable_drag(), drag);
-
-  liftDragMsg.set_alpha(alpha);
-  liftDragMsg.set_speed_ld(u);
-  liftDragMsg.set_lift_coeff(cl);
-  liftDragMsg.set_drag_coeff(cd);
-
-  msgs::Set(liftDragMsg.mutable_vel(), vel);
-  // msgs::Set(liftDragMsg.mutable_vel_ld(), velLD);
-  msgs::Set(liftDragMsg.mutable_xr(), xr);
-  msgs::Set(liftDragMsg.mutable_force(), force);
-  msgs::Set(liftDragMsg.mutable_torque(), torque);
-
-  // Publish the message if needed
-  if (this->dataPtr->liftDragPub)
-    this->dataPtr->liftDragPub->Publish(liftDragMsg);
-
-  // gzmsg << liftDragMsg.DebugString() << "\n";
-#endif
 }
 
 }  // namespace systems


### PR DESCRIPTION
This PR fixes an error in the calculation of the angle of attack. The change corrects the projection of the in-stream velocity onto the span vector normal to the plane defined by the forward and upward vectors.

This resolves the issue of a raked rig generating lift when the boom is free to align with the apparent wind.

Other fixes include:

- Check the new lift drag model has a valid pointer.
- Update the debug info in the `LIftDrag` class.
- Removed defined out code.