### PR TITLE
Mooring: add mooring plugin

### DIFF
--- a/.github/workflows/ccpcheck.yml
+++ b/.github/workflows/ccpcheck.yml
@@ -31,9 +31,27 @@ jobs:
             ./asv_sim_gazebo_plugins/src/systems/foil_lift_drag/*.hh
           cppcheck --std=c++17 --suppress=unknownMacro \
             ./asv_sim_gazebo_plugins/src/systems/foil_lift_drag/*.cc
+      - name: Cppcheck Mooring Plugin
+        run: |
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./asv_sim_gazebo_plugins/src/systems/mooring/*.hh
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./asv_sim_gazebo_plugins/src/systems/mooring/*.cc
       - name: Cppcheck SailLiftDrag Plugin
         run: |
           cppcheck --std=c++17 --suppress=unknownMacro \
             ./asv_sim_gazebo_plugins/src/systems/sail_lift_drag/*.hh
           cppcheck --std=c++17 --suppress=unknownMacro \
             ./asv_sim_gazebo_plugins/src/systems/sail_lift_drag/*.cc
+      - name: Cppcheck SailPositionController Plugin
+        run: |
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./asv_sim_gazebo_plugins/src/systems/sail_position_controller/*.hh
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./asv_sim_gazebo_plugins/src/systems/sail_position_controller/*.cc
+      - name: Cppcheck Wind Plugin
+        run: |
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./asv_sim_gazebo_plugins/src/systems/wind/*.hh
+          cppcheck --std=c++17 --suppress=unknownMacro \
+            ./asv_sim_gazebo_plugins/src/systems/wind/*.cc

--- a/.github/workflows/ccplint.yml
+++ b/.github/workflows/ccplint.yml
@@ -36,8 +36,23 @@ jobs:
           cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard,-whitespace/newline \
             ./asv_sim_gazebo_plugins/src/systems/foil_lift_drag/*.hh \
             ./asv_sim_gazebo_plugins/src/systems/foil_lift_drag/*.cc
+      - name: Cpplint Mooring Plugin
+        run: |
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard,-whitespace/newline \
+            ./asv_sim_gazebo_plugins/src/systems/mooring/*.hh \
+            ./asv_sim_gazebo_plugins/src/systems/mooring/*.cc
       - name: Cpplint SailLiftDrag Plugin
         run: |
           cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard,-whitespace/newline \
             ./asv_sim_gazebo_plugins/src/systems/sail_lift_drag/*.hh \
             ./asv_sim_gazebo_plugins/src/systems/sail_lift_drag/*.cc
+      - name: Cpplint SailPositionController Plugin
+        run: |
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard,-whitespace/newline \
+            ./asv_sim_gazebo_plugins/src/systems/sail_position_controller/*.hh \
+            ./asv_sim_gazebo_plugins/src/systems/sail_position_controller/*.cc
+      - name: Cpplint Wind Plugin
+        run: |
+          cpplint --filter=-whitespace/blank_line,-whitespace/indent,-build/header_guard,-whitespace/newline \
+            ./asv_sim_gazebo_plugins/src/systems/wind/*.hh \
+            ./asv_sim_gazebo_plugins/src/systems/wind/*.cc

--- a/asv_sim_gazebo/worlds/mooring.sdf
+++ b/asv_sim_gazebo/worlds/mooring.sdf
@@ -1,0 +1,593 @@
+<?xml version="1.0" ?>
+<!--
+  Copyright (C) 2019-2023 Rhys Mainwaring
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<!--
+  Usage
+
+  Gazebo
+  gz sim -v4 -s -r jubilee_cat.sdf
+
+  SITL
+
+  sim_vehicle.py -D -v Rover -f rover-skid
+    -/-model json:127.0.0.1
+    -/-console
+    -/-custom-location="51.56730439904417,-4.035240867824305,10.0,0.0" 
+
+
+-->
+<sdf version="1.6">
+  <world name="waves">
+
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1</real_time_factor>
+    </physics>
+
+    <plugin filename="gz-sim-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin filename="gz-sim-sensors-system"
+      name="gz::sim::systems::Sensors">
+      <render_engine>ogre2</render_engine>
+      <background_color>0.8 0.8 0.8</background_color>
+    </plugin>
+    <plugin filename="gz-sim-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin filename="gz-sim-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin filename="gz-sim-imu-system"
+      name="gz::sim::systems::Imu">
+    </plugin>
+    <plugin filename="gz-sim-magnetometer-system"
+      name="gz::sim::systems::Magnetometer">
+    </plugin>
+   <plugin filename="gz-sim-navsat-system"
+      name="gz::sim::systems::NavSat">
+    </plugin>
+    <plugin filename="gz-sim-wind-effects-system"
+      name="gz::sim::systems::WindEffects">
+      <force_approximation_scaling_factor>0.1</force_approximation_scaling_factor>
+    </plugin>
+
+    <plugin filename="asv_sim2-anemometer-system"
+        name="gz::sim::systems::Anemometer">
+    </plugin>
+    <plugin filename="asv_sim2-wind-system"
+      name="gz::sim::systems::Wind">
+      <topic>/wind</topic>
+    </plugin>
+
+    <scene>
+      <ambient>1.0 1.0 1.0</ambient>
+      <background>0.8 0.8 0.8</background>
+      <sky></sky>
+    </scene>
+
+    <spherical_coordinates>
+      <latitude_deg>51.56730439904417</latitude_deg>
+      <longitude_deg>-4.035240867824305</longitude_deg>
+      <elevation>10.0</elevation>
+      <heading_deg>0</heading_deg>
+      <surface_model>EARTH_WGS84</surface_model>
+    </spherical_coordinates>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.6 0.6 0.6 1</specular>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <wind>
+      <linear_velocity>0 -10 0</linear_velocity>
+    </wind>
+
+    <include>
+      <pose>0 0 0 0 0 0</pose>
+      <uri>model://waves</uri>
+    </include>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <pose>0 0 -10 0 0 0</pose>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="axes">
+      <static>1</static>
+      <link name="link">
+        <visual name="r">
+          <cast_shadows>0</cast_shadows>
+          <pose>5 0 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>10 0.01 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <emissive>1 0 0 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+        <visual name="g">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 5 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 10 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 1 0 1</ambient>
+            <diffuse>0 1 0 1</diffuse>
+            <emissive>0 1 0 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+        <visual name="b">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 0 5.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 0.01 10</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+            <emissive>0 0 1 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <model name="buoy_wp1">
+      <pose>10 0 0.5 0 0 0</pose>
+      <enable_wind>true</enable_wind>
+      <link name="base_link">
+        <inertial>
+          <mass>5</mass>
+          <inertia>
+            <ixx>0.494791667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.494791667</iyy>
+            <iyz>0</iyz>
+            <izz>0.15625</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+      <link name="bridle_link">
+        <pose>0 0 -0.5 0 0 0</pose>
+        <inertial>
+          <mass>10</mass>
+          <inertia>
+            <ixx>0.01000</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.01000</iyy>
+            <iyz>0</iyz>
+            <izz>0.01000</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 0.5 1</ambient>
+            <diffuse>0.5 0.5 0.5 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+      <joint name="bridle_joint" type="revolute">
+        <child>bridle_link</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+          </limit>
+          <dynamics>
+            <damping>1.0</damping>
+          </dynamics>
+        </axis>
+      </joint>
+
+      <plugin
+        filename="gz-waves1-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <enable>buoy_wp1::base_link</enable>
+      </plugin>
+
+      <plugin
+        filename="asv_sim2-mooring-system"
+        name="gz::sim::systems::Mooring">
+        <link_name>bridle_link</link_name>
+        <anchor_position>10 0 -10</anchor_position>
+        <chain_length>15.0</chain_length>
+        <chain_mass_per_metre>1.0</chain_mass_per_metre>
+      </plugin>
+    </model>
+
+    <model name="buoy_wp2">
+      <pose>0 10 0.5 0 0 0</pose>
+      <enable_wind>true</enable_wind>
+      <link name="base_link">
+        <inertial>
+          <mass>5</mass>
+          <inertia>
+            <ixx>0.494791667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.494791667</iyy>
+            <iyz>0</iyz>
+            <izz>0.15625</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+      <link name="bridle_link">
+        <pose>0 0 -0.5 0 0 0</pose>
+        <inertial>
+          <mass>10</mass>
+          <inertia>
+            <ixx>0.01000</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.01000</iyy>
+            <iyz>0</iyz>
+            <izz>0.01000</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 0.5 1</ambient>
+            <diffuse>0.5 0.5 0.5 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+      <joint name="bridle_joint" type="revolute">
+        <child>bridle_link</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+          </limit>
+          <dynamics>
+            <damping>1.0</damping>
+          </dynamics>
+        </axis>
+      </joint>
+
+      <plugin
+        filename="gz-waves1-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <enable>buoy_wp2::base_link</enable>
+      </plugin>
+
+      <plugin
+        filename="asv_sim2-mooring-system"
+        name="gz::sim::systems::Mooring">
+        <link_name>bridle_link</link_name>
+        <anchor_position>0 10 -10</anchor_position>
+        <chain_length>15.0</chain_length>
+        <chain_mass_per_metre>1.0</chain_mass_per_metre>
+      </plugin>
+    </model>
+
+    <model name="buoy_wp3">
+      <pose>-10 0 0.5 0 0 0</pose>
+      <enable_wind>true</enable_wind>
+      <link name="base_link">
+        <inertial>
+          <mass>5</mass>
+          <inertia>
+            <ixx>0.494791667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.494791667</iyy>
+            <iyz>0</iyz>
+            <izz>0.15625</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+      <link name="bridle_link">
+        <pose>0 0 -0.5 0 0 0</pose>
+        <inertial>
+          <mass>10</mass>
+          <inertia>
+            <ixx>0.01000</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.01000</iyy>
+            <iyz>0</iyz>
+            <izz>0.01000</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 0.5 1</ambient>
+            <diffuse>0.5 0.5 0.5 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+      <joint name="bridle_joint" type="revolute">
+        <child>bridle_link</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+          </limit>
+          <dynamics>
+            <damping>1.0</damping>
+          </dynamics>
+        </axis>
+      </joint>
+
+      <plugin
+        filename="gz-waves1-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <enable>buoy_wp3::base_link</enable>
+      </plugin>
+
+      <plugin
+        filename="asv_sim2-mooring-system"
+        name="gz::sim::systems::Mooring">
+        <link_name>bridle_link</link_name>
+        <anchor_position>-10 0 -10</anchor_position>
+        <chain_length>15.0</chain_length>
+        <chain_mass_per_metre>1.0</chain_mass_per_metre>
+      </plugin>
+    </model>
+
+    <model name="buoy_wp4">
+      <pose>0 -10 0.5 0 0 0</pose>
+      <enable_wind>true</enable_wind>
+      <link name="base_link">
+        <inertial>
+          <mass>5</mass>
+          <inertia>
+            <ixx>0.494791667</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.494791667</iyy>
+            <iyz>0</iyz>
+            <izz>0.15625</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <cylinder>
+              <radius>0.25</radius>
+              <length>1.0</length>
+            </cylinder>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+      <link name="bridle_link">
+        <pose>0 0 -0.5 0 0 0</pose>
+        <inertial>
+          <mass>10</mass>
+          <inertia>
+            <ixx>0.01000</ixx>
+            <ixy>0</ixy>
+            <ixz>0</ixz>
+            <iyy>0.01000</iyy>
+            <iyz>0</iyz>
+            <izz>0.01000</izz>
+          </inertia>
+        </inertial>
+        <collision name="collision">
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <sphere>
+              <radius>0.1</radius>
+            </sphere>
+          </geometry>
+          <material>
+            <ambient>0.5 0.5 0.5 1</ambient>
+            <diffuse>0.5 0.5 0.5 1</diffuse>
+            <specular>0.1 0.1 0.1 1</specular>
+          </material>
+        </visual>
+      </link>
+      <joint name="bridle_joint" type="revolute">
+        <child>bridle_link</child>
+        <parent>base_link</parent>
+        <axis>
+          <xyz>0 0 1</xyz>
+          <limit>
+            <lower>0</lower>
+            <upper>0</upper>
+          </limit>
+          <dynamics>
+            <damping>1.0</damping>
+          </dynamics>
+        </axis>
+      </joint>
+
+      <plugin
+        filename="gz-waves1-hydrodynamics-system"
+        name="gz::sim::systems::Hydrodynamics">
+        <enable>buoy_wp4::base_link</enable>
+      </plugin>
+
+      <plugin
+        filename="asv_sim2-mooring-system"
+        name="gz::sim::systems::Mooring">
+        <link_name>bridle_link</link_name>
+        <anchor_position>0 -10 -10</anchor_position>
+        <chain_length>15.0</chain_length>
+        <chain_mass_per_metre>1.0</chain_mass_per_metre>
+      </plugin>
+    </model>
+
+  </world>
+</sdf>

--- a/asv_sim_gazebo_plugins/src/systems/CMakeLists.txt
+++ b/asv_sim_gazebo_plugins/src/systems/CMakeLists.txt
@@ -89,6 +89,7 @@ endfunction()
 
 add_subdirectory(anemometer)
 add_subdirectory(foil_lift_drag)
+add_subdirectory(mooring)
 add_subdirectory(sail_lift_drag)
 add_subdirectory(sail_position_controller)
 add_subdirectory(wind)

--- a/asv_sim_gazebo_plugins/src/systems/anemometer/Anemometer.cc
+++ b/asv_sim_gazebo_plugins/src/systems/anemometer/Anemometer.cc
@@ -179,7 +179,7 @@ Anemometer::Anemometer()
 
 /////////////////////////////////////////////////
 void Anemometer::PreUpdate(
-    const UpdateInfo &_info,
+    const UpdateInfo &/*_info*/,
     EntityComponentManager &_ecm)
 {
   _ecm.EachNew<gz::sim::components::CustomSensor,

--- a/asv_sim_gazebo_plugins/src/systems/foil_lift_drag/FoilLiftDrag.cc
+++ b/asv_sim_gazebo_plugins/src/systems/foil_lift_drag/FoilLiftDrag.cc
@@ -62,7 +62,7 @@ class FoilLiftDragPrivate
   public: Model model{kNullEntity};
 
   /// \brief Link interface.
-  public: Link link{kNullEntity};;
+  public: Link link{kNullEntity};
 
   /// \brief Gazebo communication node.
   public: transport::Node node;
@@ -97,7 +97,7 @@ void FoilLiftDrag::Configure(
     const Entity &_entity,
     const std::shared_ptr<const sdf::Element> &_sdf,
     EntityComponentManager &_ecm,
-    EventManager &_eventMgr)
+    EventManager &/*_eventMgr*/)
 {
   this->dataPtr->model = Model(_entity);
 

--- a/asv_sim_gazebo_plugins/src/systems/mooring/CMakeLists.txt
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/CMakeLists.txt
@@ -1,0 +1,7 @@
+gz_add_system(mooring
+  SOURCES
+    Mooring.cc
+  PUBLIC_LINK_LIBS
+    gz-common${GZ_COMMON_VER}::gz-common${GZ_COMMON_VER}
+    gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
+)

--- a/asv_sim_gazebo_plugins/src/systems/mooring/CatenarySoln.hh
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/CatenarySoln.hh
@@ -26,9 +26,9 @@
 #ifndef ASV_SIM_CATENARYSOLN_HH_
 #define ASV_SIM_CATENARYSOLN_HH_
 
-#include <cmath>
-
 #include <eigen3/unsupported/Eigen/NonLinearOptimization>
+
+#include <cmath>
 
 #include <gz/common/Console.hh>
 

--- a/asv_sim_gazebo_plugins/src/systems/mooring/CatenarySoln.hh
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/CatenarySoln.hh
@@ -1,0 +1,141 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ASV_SIM_CATENARYSOLN_HH_
+#define ASV_SIM_CATENARYSOLN_HH_
+
+#include <cmath>
+
+#include <eigen3/unsupported/Eigen/NonLinearOptimization>
+
+#include <gz/common/Console.hh>
+
+namespace gz
+{
+namespace sim
+{
+// Inline bracket to help doxygen filtering.
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace systems
+{
+
+/////////////////////////////////////////////////
+template<typename _Scalar, int NX = Eigen::Dynamic, int NY = Eigen::Dynamic>
+struct Functor
+{
+  typedef _Scalar Scalar;
+  enum { InputsAtCompileTime = NX, ValuesAtCompileTime = NY };
+  typedef Eigen::Matrix<Scalar, InputsAtCompileTime, 1> InputType;
+  typedef Eigen::Matrix<Scalar, ValuesAtCompileTime, 1> ValueType;
+  typedef Eigen::Matrix<Scalar, ValuesAtCompileTime, InputsAtCompileTime>
+    JacobianType;
+
+  const int m_inputs, m_values;
+
+  Functor()
+  : m_inputs(InputsAtCompileTime), m_values(ValuesAtCompileTime)
+  {
+  }
+  Functor(int inputs, int values)
+  : m_inputs(inputs), m_values(values)
+  {
+  }
+
+  int inputs() const
+  {
+    return m_inputs;
+  }
+  int values() const
+  {
+    return m_values;
+  }
+
+  // you should define that in the subclass :
+  // int operator() (const InputType& x, ValueType* v, JacobianType* _j=0)
+  // const;
+};
+
+/////////////////////////////////////////////////
+struct CatenaryFunction
+{
+public:
+  /// \brief Scaling factor for catenary chain
+  /// V: meters, vertical distance from buoy to anchor
+  /// B: Meters, length of mooring chain lying on seafloor, start of catenary
+  /// L: meters, total length of mooring chain
+  /// Returns c, scaling factor, ratio of horizontal component of chain tension
+  /// and weight of cable per unit length
+  static double CatenaryScalingFactor(double _V, double _B, double _L)
+  {
+    // Scaling factor c
+    return (pow((_L - _B), 2) - pow(_V, 2)) / (2. * _V);
+  }
+};
+
+/////////////////////////////////////////////////
+struct CatenaryHSoln : Functor<double>
+{
+private:
+   /// \brief Meters, vertical distance from buoy to anchor
+   double V = 82.0;
+
+   /// \brief Meters, horizontal distance from buoy to anchor
+   double H = 120.0;
+
+   /// \brief Meters, total length of mooring chain
+   double L = 160.0;
+
+   /// \brief For performance, set to true to skip solving vor CatenaryVSoln.
+   /// For accuracy, set to false.
+   bool SKIP_V_SOLVER = true;
+
+public:
+  CatenaryHSoln(double _V, double _H, double _L)
+  : Functor<double>(1, 1),
+    V(_V),
+    H(_H),
+    L(_L)
+  {
+  }
+
+  /// \brief Invert the catenary equation and solve for the horizontal input.
+  ///
+  /// \brief B length of chain on floor.
+  double InverseCatenaryVSoln(double B) const
+  {
+    double c = CatenaryFunction::CatenaryScalingFactor(this->V, B, this->L);
+    return c * std::acosh(this->V / c + 1.0) + B;
+  }
+
+  // Know 0 <= B < L - V. Take in B = L - V - b as initial guess
+  int operator()(const Eigen::VectorXd & B, Eigen::VectorXd & fvec) const
+  {
+    if (B.size() < 1) {
+      ignerr << "Invalid input size for CatenaryHSoln::operator()" << std::endl;
+      return -1;
+    }
+
+    // Evaluate target function
+    fvec[0] = this->InverseCatenaryVSoln(B[0]) - this->H;
+
+    return 0;
+  }
+};
+
+}  // namespace systems
+}
+}  // namespace sim
+}  // namespace gz
+
+#endif  // ASV_SIM_CATENARYSOLN_HH_

--- a/asv_sim_gazebo_plugins/src/systems/mooring/CatenarySoln.hh
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/CatenarySoln.hh
@@ -105,13 +105,13 @@ struct CatenaryFunction
 struct CatenaryHSoln : Functor<double>
 {
   /// \brief Vertical distance from buoy to anchor (metres).
-  private: double V = 82.0;
+  private: double V{std::nanf("")};
 
   /// \brief Horizontal distance from buoy to anchor (metres).
-  private: double H = 120.0;
+  private: double H{std::nanf("")};
 
   /// \brief Total length of mooring chain (metres).
-  private: double L = 160.0;
+  private: double L{std::nanf("")};
 
   /// \brief Constructor.
   public: CatenaryHSoln(double _V, double _H, double _L)

--- a/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.cc
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.cc
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Rhys Mainwaring
+// Copyright (C) 2023 Rhys Mainwaring
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,7 +20,8 @@
 //          Michael Anderson <anderson@mbari.org>
 //          Rhys Mainwaring <rhys.mainwaring@me.com>
 
-// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//                and Monterey Bay Aquarium Research Institute
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.cc
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.cc
@@ -13,7 +13,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-// Adapted from the MooringForce system developed for the MBARI wave buoy.
+// Adapted from the MooringForce system developed for the MBARI wave buoy
+// including https://github.com/osrf/buoy_sim/pull/135
+//
+// Authors: Mabel Zhang <mabel@openrobotics.org>
+//          Michael Anderson <anderson@mbari.org>
+//          Rhys Mainwaring <rhys.mainwaring@me.com>
 
 // Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
 //

--- a/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.cc
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.cc
@@ -89,13 +89,13 @@ class MooringPrivate
   // public: double effectiveRadius = 90.0;
 
   /// \brief Mass of chain per unit length (kg/m)
-  public: double chainMassPerMetre{{std::nanf("")}};
+  public: double chainMassPerMetre{std::nanf("")};
 
   /// \brief Weight of chain per unit length (N/m).
   public: double w{std::nanf("")};
 
   /// \brief radians, atan2 angle of buoy from anchor
-  public: double theta{{std::nanf("")}};
+  public: double theta{std::nanf("")};
 
   /// \brief Catenary equation to pass to solver
   public: std::unique_ptr<CatenaryHSoln> catenarySoln;
@@ -190,7 +190,7 @@ void Mooring::Configure(
     const Entity &_entity,
     const std::shared_ptr<const sdf::Element> &_sdf,
     EntityComponentManager &_ecm,
-    EventManager &_eventMgr)
+    EventManager &/*_eventMgr*/)
 {
   this->dataPtr->model = sim::Model(_entity);
   if (!this->dataPtr->model.Valid(_ecm))

--- a/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.cc
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.cc
@@ -1,0 +1,413 @@
+// Copyright (C) 2019-2023 Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+// Adapted from the MooringForce system developed for the MBARI wave buoy.
+
+// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Mooring.hh"
+
+#include <memory>
+#include <string>
+
+#include <gz/common/Profiler.hh>
+#include <gz/plugin/Register.hh>
+#include <gz/sim/Link.hh>
+#include <gz/sim/Model.hh>
+#include <gz/sim/World.hh>
+#include <gz/sim/Util.hh>
+
+namespace gz
+{
+namespace sim
+{
+namespace systems
+{
+/////////////////////////////////////////////////
+class MooringPrivate
+{
+  /// \brief Buoy link entity
+  public: gz::sim::Entity buoyLinkEnt{gz::sim::kNullEntity};
+
+  /// \brief Buoy link on water surface
+  public: gz::sim::Link buoyLink;
+
+  /// \brief World pose of buoy link
+  public: gz::math::Vector3d buoyPos;
+
+  /// \brief Heave cone link entity
+  public: gz::sim::Entity heaveConeLinkEnt{gz::sim::kNullEntity};
+
+  /// \brief Heave cone link to which the virtual mooring is attached
+  public: gz::sim::Link heaveConeLink;
+
+  /// \brief A predefined pose we assume the anchor to be
+  public: gz::math::Vector3d anchorPos{20.0, 0.0, -77.0};
+
+  /// \brief Model interface
+  public: gz::sim::Model model{gz::sim::kNullEntity};
+
+  /// \brief Meters, vertical distance from buoy to anchor. Updated per
+  /// iteration
+  public: double V = 82.0;
+
+  /// \brief Meters, total length of mooring chain
+  public: double L = 160.0;
+
+  /// \brief Meters, horizontal distance from buoy to anchor. Updated per
+  /// iteration
+  public: double H = 120.0;
+
+  /// \brief Distance of buoy from anchor, beyond which (i.e. H > radius)
+  /// mooring force is applied. Within the radius, no or negligible catenary
+  /// curve is formed, and no mooring force will be applied.
+  public: double effectiveRadius = 90.0;
+
+  /// \brief N/m, weight of chain per unit length
+  public: double w = 20.0;
+
+  /// \brief radians, atan2 angle of buoy from anchor
+  public: double theta = 0.0;
+
+  /// \brief Catenary equation to pass to solver
+  public: std::unique_ptr<CatenaryHSoln> catenarySoln;
+
+  /// \brief Solution to catenary equation. Meters, length of chain laying on
+  /// the bottom, start of catenary.
+  public: Eigen::VectorXd B{};
+
+  /// \brief If we have notified when inside effective radius.
+  public: bool notifiedInsideEffectiveRadius{false};
+
+  /// \brief Debug print period calculated from <debug_print_rate>
+  public: std::chrono::steady_clock::duration debugPrintPeriod{0};
+
+  /// \brief Last debug print simulation time
+  public: std::chrono::steady_clock::duration lastDebugPrintTime{0};
+
+  /// \brief Constructor
+  public: MooringPrivate();
+
+  /// \brief Look for buoy link to find input to catenary equation, and heave
+  /// cone link to apply output force to
+  public: bool FindLinks(gz::sim::EntityComponentManager & _ecm);
+
+  /// \brief Update V and H for solver input
+  public: void UpdateVH(gz::sim::EntityComponentManager & _ecm);
+};
+
+//////////////////////////////////////////////////
+MooringPrivate::MooringPrivate()
+    : catenarySoln(std::make_unique<CatenaryHSoln>(V, H, L))
+{
+}
+
+//////////////////////////////////////////////////
+bool MooringPrivate::FindLinks(
+  gz::sim::EntityComponentManager & _ecm)
+{
+  // Look for buoy link to get input for catenary equation
+  this->buoyLinkEnt = this->model.LinkByName(_ecm,
+    "Buoy");
+  if (this->buoyLinkEnt != gz::sim::kNullEntity) {
+    this->buoyLink = gz::sim::Link(
+      this->buoyLinkEnt);
+    if (!this->buoyLink.Valid(_ecm))
+    {
+      gzwarn << "Could not find valid buoy link. Mooring force may "
+        << "not be calculated correctly." << std::endl;
+      return false;
+    }
+  }
+  else {
+    gzwarn << "Could not find valid buoy link. Mooring force may "
+      << "not be calculated correctly." << std::endl;
+    return false;
+  }
+
+  // Look for heave cone link to apply force to
+  this->heaveConeLinkEnt = this->model.LinkByName(_ecm,
+    "HeaveCone");
+  if (this->heaveConeLinkEnt != gz::sim::kNullEntity) {
+    this->heaveConeLink = gz::sim::Link(
+      this->heaveConeLinkEnt);
+    if (!this->heaveConeLink.Valid(_ecm))
+    {
+      gzwarn << "Could not find valid heave cone link. Mooring force may "
+        << "not be applied correctly." << std::endl;
+      return false;
+    }
+  }
+  else {
+    gzwarn << "Could not find valid heave cone link. Mooring force may "
+      << "not be applied correctly." << std::endl;
+    return false;
+  }
+
+  return true;
+}
+
+/////////////////////////////////////////////////
+void MooringPrivate::UpdateVH(
+  gz::sim::EntityComponentManager & _ecm)
+{
+  // If necessary links not found yet, nothing to do
+  if (this->heaveConeLinkEnt == gz::sim::kNullEntity ||
+    this->buoyLinkEnt == gz::sim::kNullEntity) {
+    return;
+  }
+
+  // Get buoy position in world
+  auto buoyPose = this->buoyLink.WorldPose(_ecm);
+  this->buoyPos = buoyPose->Pos();
+
+  // Update vertical (z) distance between buoy and anchor
+  this->V = fabs(this->buoyPos[2U] - this->anchorPos[2U]);
+
+  // Update horizontal distance between buoy and anchor
+  this->H = sqrt(
+    (this->buoyPos[0U] - this->anchorPos[0U]) *
+    (this->buoyPos[0U] - this->anchorPos[0U]) +
+    (this->buoyPos[1U] - this->anchorPos[1U]) *
+    (this->buoyPos[1U] - this->anchorPos[1U]));
+
+  // Update angle between buoy and anchor
+  this->theta = atan2(this->buoyPos[1U] - this->anchorPos[1U],
+    this->buoyPos[0U] - this->anchorPos[0U]);
+
+  this->catenarySoln.reset(new CatenaryHSoln(this->V, this->H, this->L));
+}
+
+/////////////////////////////////////////////////
+/////////////////////////////////////////////////
+Mooring::~Mooring() = default;
+
+/////////////////////////////////////////////////
+Mooring::Mooring()
+  : System(), dataPtr(std::make_unique<MooringPrivate>())
+{
+}
+
+/////////////////////////////////////////////////
+void Mooring::Configure(
+    const Entity &_entity,
+    const std::shared_ptr<const sdf::Element> &_sdf,
+    EntityComponentManager &_ecm,
+    EventManager &_eventMgr)
+{
+  // Skip debug messages to run faster TODO change to 3 before merge PR
+  gz::common::Console::SetVerbosity(4);
+
+  this->dataPtr->model = gz::sim::Model(_entity);
+  if (!this->dataPtr->model.Valid(_ecm)) {
+    gzerr << "MooringForce plugin should be attached to a model entity. " <<
+      "Failed to initialize." << std::endl;
+    return;
+  }
+
+  this->dataPtr->anchorPos = _sdf->Get<gz::math::Vector3d>(
+    "anchor_position", this->dataPtr->anchorPos).first;
+  gzdbg << "Anchor position set to " << this->dataPtr->anchorPos
+    << std::endl;
+
+  this->dataPtr->effectiveRadius = _sdf->Get<double>(
+    "enable_beyond_radius", this->dataPtr->effectiveRadius).first;
+  gzdbg << "Effective radius set to beyond " << this->dataPtr->effectiveRadius
+    << std::endl;
+
+  if (_sdf->HasElement("chain_length"))
+  {
+    this->dataPtr->L = _sdf->Get<double>(
+      "chain_length", this->dataPtr->L).first;
+    gzdbg << "Mooring chain length set to " << this->dataPtr->L
+      << std::endl;
+  }
+
+  // Find necessary model links
+  if (this->dataPtr->FindLinks(_ecm)) {
+    this->dataPtr->UpdateVH(_ecm);
+  }
+
+  this->dataPtr->B.resize(1U);
+
+  // debug print throttle, default 1Hz
+  {
+    double rate(1.0);
+    if (_sdf->HasElement("debug_print_rate"))
+    {
+      rate = _sdf->Get<double>(
+        "debug_print_rate", this->dataPtr->L).first;
+      gzdbg << "Debug print rate set to " << this->dataPtr->L
+        << std::endl;
+    }
+    std::chrono::duration<double> period{rate > 0.0 ? 1.0 / rate : 0.0};
+    this->dataPtr->debugPrintPeriod = std::chrono::duration_cast<
+        std::chrono::steady_clock::duration>(period);
+  }
+}
+
+/////////////////////////////////////////////////
+void Mooring::PreUpdate(
+    const UpdateInfo &_info,
+    EntityComponentManager &_ecm)
+{
+  GZ_PROFILE("MooringForce::PreUpdate");
+
+  // If necessary links have not been identified yet, the plugin is disabled
+  if (this->dataPtr->heaveConeLinkEnt == gz::sim::kNullEntity ||
+    this->dataPtr->buoyLinkEnt == gz::sim::kNullEntity)
+  {
+    this->dataPtr->FindLinks(_ecm);
+    gzerr << "Could not find heave cone and buoy links in ECM.\n";
+    return;
+  }
+
+  // TODO(anyone): Support rewind
+  if (_info.dt < std::chrono::steady_clock::duration::zero()) {
+    gzwarn << "Detected jump back in time [" <<
+      std::chrono::duration_cast<std::chrono::seconds>(_info.dt).count() <<
+      "s]. System may not work properly." << std::endl;
+  }
+
+  // Nothing left to do if paused.
+  if (_info.paused) {
+    return;
+  }
+
+  // Update V and H based on latest buoy position
+  this->dataPtr->UpdateVH(_ecm);
+  // If buoy is not far enough from anchor for there to be a need to pull it
+  // back, no need to apply mooring force
+  if (this->dataPtr->H < this->dataPtr->effectiveRadius)
+  {
+    if (!this->dataPtr->notifiedInsideEffectiveRadius)
+    {
+      this->dataPtr->notifiedInsideEffectiveRadius = true;
+      gzmsg << "Buoy horizontal radius H [" << this->dataPtr->H << "]"
+            << " is inside effective radius R ["
+            << this->dataPtr->effectiveRadius << "]"
+            << " skipping force update.\n";
+    }
+    return;
+  }
+  this->dataPtr->notifiedInsideEffectiveRadius = false;
+
+  Eigen::HybridNonLinearSolver<CatenaryHSoln> catenarySolver(
+    *this->dataPtr->catenarySoln);
+  // Tolerance for error between two consecutive iterations
+  catenarySolver.parameters.xtol = 0.001;
+  // Max number of calls to the function
+  catenarySolver.parameters.maxfev = 20;
+  catenarySolver.diag.setConstant(1, 1.0);
+  // Improves solution stability dramatically.
+  catenarySolver.useExternalScaling = true;
+
+  // Initial estimate for B (upper bound).
+  auto BMax = [](double V, double H, double L) -> double
+  {
+    return (L*L - (V*V + H*H)) / (2 * (L - H));
+  };
+
+  double bMax = BMax(this->dataPtr->V, this->dataPtr->H, this->dataPtr->L);
+
+  this->dataPtr->B[0] = bMax;
+  int solverInfo = catenarySolver.solveNumericalDiff(this->dataPtr->B);
+
+  double c = CatenaryFunction::CatenaryScalingFactor(
+    this->dataPtr->V, this->dataPtr->B[0U], this->dataPtr->L);
+
+  // Horizontal component of chain tension, in Newtons
+  // Force at buoy heave cone is Fx = -Tx
+  double Tr = - c * this->dataPtr->w;
+  double Tx = Tr * cos(this->dataPtr->theta);
+  double Ty = Tr * sin(this->dataPtr->theta);
+  // Vertical component of chain tension at buoy heave cone, in Newtons.
+  // Unused at the moment
+  double Tz = - this->dataPtr->w * (this->dataPtr->L - this->dataPtr->B[0U]);
+
+  // Throttle update rate
+  auto elapsed = _info.simTime - this->dataPtr->lastDebugPrintTime;
+  if (elapsed > std::chrono::steady_clock::duration::zero() &&
+      elapsed >= this->dataPtr->debugPrintPeriod)
+  {
+    this->dataPtr->lastDebugPrintTime = _info.simTime;
+    gzdbg << "HSolver solverInfo: " << solverInfo << "\n"
+      << " t: " << std::chrono::duration_cast<
+          std::chrono::milliseconds>(_info.simTime).count()/1000.0 << "\n"
+      << " Anchor: " << this->dataPtr->anchorPos << "\n"
+      << " Buoy:   " << this->dataPtr->buoyPos << "\n"
+      << " R: " << this->dataPtr->effectiveRadius << "\n"
+      << " L: " << this->dataPtr->L << "\n"
+      << " V: " << this->dataPtr->V << "\n"
+      << " H: " << this->dataPtr->H << "\n"
+      << " b: " << bMax << "\n"
+      << " B: " << this->dataPtr->B[0U] << "\n"
+      << " c: " << c << "\n"
+      << " theta: " << this->dataPtr->theta << "\n"
+      << " Tx: " << Tx << "\n"
+      << " Ty: " << Ty << "\n"
+      << " Tr: " << Tr << "\n"
+      << " Tz: " << Tz << "\n"
+      << " nfev: " << catenarySolver.nfev << "\n"
+      << " iter: " << catenarySolver.iter << "\n"
+      << " fnorm: " << catenarySolver.fnorm << "\n"
+      << "\n";
+  }
+
+  // Did not find solution. Maybe shouldn't apply a force that doesn't make sense
+  if (solverInfo != 1) {
+    gzerr << "HSolver failed to converge, solverInfo: " << solverInfo << "\n";
+    return;
+  }
+
+  // Apply forces to buoy heave cone link, where the mooring would be attached
+  gz::math::Vector3d force(Tx, Ty, 0.0);
+  gz::math::Vector3d torque = gz::math::Vector3d::Zero;
+  if (force.IsFinite())
+  {
+    // this->dataPtr->buoyLink.SetVisualizationLabel("MooringForce");
+    this->dataPtr->buoyLink.AddWorldWrench(_ecm, force, torque);
+  }
+  else
+  {
+    gzerr << "Mooring force is not finite\n";
+  }
+}
+
+}  // namespace systems
+}  // namespace sim
+}  // namespace gz
+
+GZ_ADD_PLUGIN(
+    gz::sim::systems::Mooring,
+    gz::sim::System,
+    gz::sim::systems::Mooring::ISystemConfigure,
+    gz::sim::systems::Mooring::ISystemPreUpdate)
+
+GZ_ADD_PLUGIN_ALIAS(
+    gz::sim::systems::Mooring,
+    "gz::sim::systems::Mooring")

--- a/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.hh
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.hh
@@ -1,0 +1,71 @@
+// Copyright (C) 2019-2023 Rhys Mainwaring
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#ifndef ASV_SIM_MOORING_HH_
+#define ASV_SIM_MOORING_HH_
+
+#include <memory>
+#include <string>
+
+#include <gz/sim/System.hh>
+
+#include "CatenarySoln.hh"
+
+namespace gz
+{
+namespace sim
+{
+// Inline bracket to help doxygen filtering.
+inline namespace GZ_SIM_VERSION_NAMESPACE {
+namespace systems
+{
+
+// Forward declarations.
+class MooringPrivate;
+
+/// \brief A plugin that simulates a mooring.
+class Mooring
+    : public System,
+      public ISystemConfigure,
+      public ISystemPreUpdate
+{
+  /// \brief Destructor.
+  public: virtual ~Mooring();
+
+  /// \brief Constructor.
+  public: Mooring();
+
+  // Documentation inherited
+  public: void Configure(
+      const Entity &_entity,
+      const std::shared_ptr<const sdf::Element> &_sdf,
+      EntityComponentManager &_ecm,
+      EventManager &_eventMgr) final;
+
+  /// Documentation inherited
+  public: void PreUpdate(
+      const UpdateInfo &_info,
+      EntityComponentManager &_ecm) override;
+
+  /// \brief Private data pointer.
+  private: std::unique_ptr<MooringPrivate> dataPtr;
+};
+
+}  // namespace systems
+}
+}  // namespace sim
+}  // namespace gz
+
+#endif  // ASV_SIM_MOORING_HH_

--- a/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.hh
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.hh
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2023 Rhys Mainwaring
+// Copyright (C) 2023 Rhys Mainwaring
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -21,7 +21,8 @@
 //          Michael Anderson <anderson@mbari.org>
 //          Rhys Mainwaring <rhys.mainwaring@me.com>
 
-// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//                and Monterey Bay Aquarium Research Institute
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,7 +35,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 
 
 #ifndef ASV_SIM_MOORING_HH_

--- a/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.hh
+++ b/asv_sim_gazebo_plugins/src/systems/mooring/Mooring.hh
@@ -13,6 +13,30 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+
+// Adapted from the MooringForce system developed for the MBARI wave buoy
+// including https://github.com/osrf/buoy_sim/pull/135
+//
+// Authors: Mabel Zhang <mabel@openrobotics.org>
+//          Michael Anderson <anderson@mbari.org>
+//          Rhys Mainwaring <rhys.mainwaring@me.com>
+
+// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+
 #ifndef ASV_SIM_MOORING_HH_
 #define ASV_SIM_MOORING_HH_
 

--- a/asv_sim_gazebo_plugins/src/systems/sail_lift_drag/SailLiftDrag.cc
+++ b/asv_sim_gazebo_plugins/src/systems/sail_lift_drag/SailLiftDrag.cc
@@ -62,7 +62,7 @@ class SailLiftDragPrivate
   public: Model model{kNullEntity};
 
   /// \brief Link interface.
-  public: Link link{kNullEntity};;
+  public: Link link{kNullEntity};
 
   /// \brief Gazebo communication node.
   public: transport::Node node;
@@ -97,7 +97,7 @@ void SailLiftDrag::Configure(
     const Entity &_entity,
     const std::shared_ptr<const sdf::Element> &_sdf,
     EntityComponentManager &_ecm,
-    EventManager &_eventMgr)
+    EventManager &/*_eventMgr*/)
 {
   this->dataPtr->model = Model(_entity);
 

--- a/asv_sim_gazebo_plugins/src/systems/sail_position_controller/SailPositionController.cc
+++ b/asv_sim_gazebo_plugins/src/systems/sail_position_controller/SailPositionController.cc
@@ -111,7 +111,7 @@ void SailPositionController::Configure(
     const Entity &_entity,
     const std::shared_ptr<const sdf::Element> &_sdf,
     EntityComponentManager &_ecm,
-    EventManager &_eventMgr)
+    EventManager &/*_eventMgr*/)
 {
   this->dataPtr->model = Model(_entity);
 

--- a/asv_sim_gazebo_plugins/src/systems/wind/Wind.cc
+++ b/asv_sim_gazebo_plugins/src/systems/wind/Wind.cc
@@ -153,7 +153,7 @@ void Wind::PreUpdate(
     this->dataPtr->hasWindChanged = false;
 
     std::lock_guard<std::mutex> lock(this->dataPtr->windVelocityMutex);
-  
+
     Entity windEntity = _ecm.EntityByComponents(components::Wind());
 
     auto windVelComp =

--- a/asv_sim_gazebo_plugins/src/systems/wind/Wind.cc
+++ b/asv_sim_gazebo_plugins/src/systems/wind/Wind.cc
@@ -85,7 +85,7 @@ void Wind::Configure(
     const Entity &_entity,
     const std::shared_ptr<const sdf::Element> &_sdf,
     EntityComponentManager &_ecm,
-    EventManager &_eventMgr)
+    EventManager &/*_eventMgr*/)
 {
   this->dataPtr->world = sim::World(_entity);
 


### PR DESCRIPTION
Add a mooring plugin based on the MooringForce system developed by MBARI in https://github.com/osrf/mbari_wec_gz/tree/mabelzhang/mooring and https://github.com/osrf/mbari_wec_gz/pull/135.

## Details

The plugin largely copies the MBARI `buoy_sim` plugin with the following changes:

- Hardcoded link names are removed and required as parameters.
- Only one link is required (the attachment point or bridle).
- Apply the vertical force (chain weight) as well as tension.
- Apply chain weight when the chain would be vertical (assuming chain length greater than sum of horizontal and vertical distance between anchor and attachment point).
- Apply Gazebo code style. 

Figure: example of four cylinder buoys moored in waves with wind effects enabled.
![mooring](https://user-images.githubusercontent.com/24916364/227951650-7b0b670b-46d5-4bfa-ad69-e1ffa11d2e5d.jpg)

