### PR TITLE
LiftDrag: fix error in torque when lift or drag are zero.

### DIFF
--- a/asv_sim_gazebo_plugins/src/LiftDragModel.cc
+++ b/asv_sim_gazebo_plugins/src/LiftDragModel.cc
@@ -156,7 +156,11 @@ void LiftDragModel::Compute(
 
   // Avoid division by zero issues.
   if (_velU.Length() <= 0.01)
+  {
+    _lift = gz::math::Vector3d::Zero;
+    _drag = gz::math::Vector3d::Zero;
     return;
+  }
 
   // Rotate forward and upward vectors into the world frame.
   auto forwardI = _bodyPose.Rot().RotateVector(this->data->forward);

--- a/asv_sim_gazebo_plugins/src/systems/foil_lift_drag/FoilLiftDrag.cc
+++ b/asv_sim_gazebo_plugins/src/systems/foil_lift_drag/FoilLiftDrag.cc
@@ -193,13 +193,13 @@ void FoilLiftDrag::PreUpdate(
   // Rotate the centre of pressure (CP) into the world frame.
   auto xr = linkPoseWorld.Rot().RotateVector(this->dataPtr->cpLink);
 
-  // Compute torque (about link origin in world frame)
-  auto liftTorque = xr.Cross(lift);
-  auto dragTorque = xr.Cross(drag);
-
   // Ensure no overflow.
   lift.Correct();
   drag.Correct();
+
+  // Compute torque (about link origin in world frame)
+  auto liftTorque = xr.Cross(lift);
+  auto dragTorque = xr.Cross(drag);
 
   // Add force and torque to link (applied at link origin in world frame).
   if (lift.IsFinite() && liftTorque.IsFinite())
@@ -210,7 +210,12 @@ void FoilLiftDrag::PreUpdate(
   }
   else
   {
-    gzwarn << "FoilLiftDrag: overflow in lift calculation\n";
+    gzwarn << "FoilLiftDrag: overflow in lift calculation\n"
+           << "Link:         " << this->dataPtr->link.Name(_ecm).value() << "\n"
+           << "xr:           " << xr << "\n"
+           << "lift:         " << lift << "\n"
+           << "liftTorque:   " << liftTorque << "\n"
+           << "\n";
   }
   if (drag.IsFinite() && dragTorque.IsFinite())
   {
@@ -220,7 +225,12 @@ void FoilLiftDrag::PreUpdate(
   }
   else
   {
-    gzwarn << "FoilLiftDrag: overflow in drag calculation\n";
+    gzwarn << "FoilLiftDrag: overflow in drag calculation\n"
+           << "Link:         " << this->dataPtr->link.Name(_ecm).value() << "\n"
+           << "xr:           " << xr << "\n"
+           << "drag:         " << drag << "\n"
+           << "dragTorque:   " << dragTorque << "\n"
+           << "\n";
   }
 }
 

--- a/asv_sim_gazebo_plugins/src/systems/sail_lift_drag/SailLiftDrag.cc
+++ b/asv_sim_gazebo_plugins/src/systems/sail_lift_drag/SailLiftDrag.cc
@@ -204,13 +204,13 @@ void SailLiftDrag::PreUpdate(
   // Rotate the centre of pressure (CP) into the world frame.
   auto xr = linkPoseWorld.Rot().RotateVector(this->dataPtr->cpLink);
 
-  // Compute torque (about link origin in world frame)
-  auto liftTorque = xr.Cross(lift);
-  auto dragTorque = xr.Cross(drag);
-
   // Ensure no overflow.
   lift.Correct();
   drag.Correct();
+
+  // Compute torque (about link origin in world frame)
+  auto liftTorque = xr.Cross(lift);
+  auto dragTorque = xr.Cross(drag);
 
 #if 0
   auto elapsed = _info.simTime - this->dataPtr->lastUpdateTime;
@@ -265,8 +265,13 @@ void SailLiftDrag::PreUpdate(
   }
   else
   {
-    gzwarn << "SailLiftDrag: overflow in lift calculation\n";
-  }
+    gzwarn << "SailLiftDrag: overflow in lift calculation.\n"
+           << "Link:         " << this->dataPtr->link.Name(_ecm).value() << "\n"
+           << "xr:           " << xr << "\n"
+           << "lift:         " << lift << "\n"
+           << "liftTorque:   " << liftTorque << "\n"
+           << "\n";
+ }
   if (drag.IsFinite() && dragTorque.IsFinite())
   {
     auto link = Link(this->dataPtr->link.Entity());
@@ -275,7 +280,12 @@ void SailLiftDrag::PreUpdate(
   }
   else
   {
-    gzwarn << "SailLiftDrag: overflow in drag calculation\n";
+    gzwarn << "SailLiftDrag: overflow in drag calculation.\n"
+           << "Link:         " << this->dataPtr->link.Name(_ecm).value() << "\n"
+           << "xr:           " << xr << "\n"
+           << "drag:         " << drag << "\n"
+           << "dragTorque:   " << dragTorque << "\n"
+           << "\n";
   }
 }
 


### PR DESCRIPTION
Follow up to #17

## Details

- When the AoA is zero, no lift is generated and the force is uninitialised. Fix this by setting lift and drag to zero.
- Calculate torques after forces are corrected for nans.